### PR TITLE
feat: allow multi-line footnotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.1.0 - November 24, 2023
+
+- Added: Support multiline footnote content.
+
 ## 1.0.0 - June 25, 2021
 
 - Added: Support definition and reference.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@
 [![](https://vsmarketplacebadge.apphb.com/rating-short/houkanshan.vscode-markdown-footnote.svg)](https://marketplace.visualstudio.com/items?itemName=houkanshan.vscode-markdown-footnote&ssr=false#review-details)
 [![](https://github.com/houkanshan/vscode-markdown-footnote/workflows/CI/badge.svg?branch=master)](https://github.com/houkanshan/vscode-markdown-footnote/actions?query=workflow%3ACI+branch%3Amaster)
 
-`[^1]` [footnote syntax](https://www.markdownguide.org/extended-syntax/#footnotes) support to VS Code's Markdown editor and preview.
+`[^1]` [footnote syntax](https://www.markdownguide.org/extended-syntax/#footnotes) support for VS Code's Markdown editor and preview.
+
+This is a fork of [Mai Hou's Markdown Footnote](https://github.com/houkanshan/vscode-markdown-footnote), with the added feature of supporting multiline footnote content.
 
 ## Features
 
-
-- Hover to preview and jump between footnote reference and content by <kbd>cmd</kbd> / <kbd>ctrl</kbd> + <kbd>click</kbd>.
+- Hover to preview and jump between footnote reference and content with <kbd>cmd</kbd> / <kbd>ctrl</kbd> + <kbd>click</kbd>.
 
   ![Hover preview](assets/hover.png)
 
@@ -23,7 +24,7 @@
 
   ![Peek footnote references](assets/peek-references.png)
 
-- Command for inserting new footnote
+- Command for inserting a new footnote.
 
   ![Click to create a new footnote](assets/click-to-create.png)
 
@@ -35,7 +36,6 @@
 
 ### TODO
 
-- Support multiline footnote content.
 - Support `pandoc-citeproc` format [citations](https://crsh.github.io/papaja_man/writing.html#citations)
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "vscode-markdown-footnote",
-  "version": "0.0.5",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.5",
+      "name": "vscode-markdown-footnote",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "markdown-it-footnote": "^3.0.3"
@@ -32,7 +33,7 @@
         "vscode-test": "^1.5.2"
       },
       "engines": {
-        "vscode": "^1.47.0"
+        "vscode": "^1.57.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,50 +1,37 @@
 {
-  "name": "vscode-markdown-footnote",
+  "name": "markdown-footnote",
   "displayName": "Markdown Footnote",
-  "publisher": "houkanshan",
-  "description": "Support markdown footnote in VSCode editor",
-  "version": "1.0.0",
+  "publisher": "heckman",
+  "description": "Supports markdown footnotes in both editor and preview",
+  "version": "1.1.0",
   "engines": {
     "vscode": "^1.57.0"
   },
-  "author": "Mai Hou <houkanshan@gmail.com>",
+  "author": "Erik Ben Heckman <erik@heckman.ca>",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/houkanshan/vscode-markdown-footnote"
+    "url": "https://github.com/heckman/markdown-footnote"
   },
   "bugs": {
-    "url": "https://github.com/houkanshan/vscode-markdown-footnote/issues"
+    "url": "https://github.com/heckman/markdown-footnote/issues"
   },
   "icon": "assets/markdown-footnote.png",
-  "keywords": [
-    "markdown",
-    "footnote",
-    "footnotes",
-    "preview",
-    "notes",
-    "note taking"
-  ],
-  "categories": [
-    "Other"
-  ],
-  "activationEvents": [
-    "onLanguage:markdown"
-  ],
+  "keywords": ["markdown", "footnote", "footnotes", "preview", "notes", "note taking"],
+  "categories": ["Other"],
+  "activationEvents": ["onLanguage:markdown"],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
       {
-        "command": "vscode-markdown-footnote.insertFootnote",
+        "command": "markdown-footnote.insertFootnote",
         "title": "Insert a Footnote"
       }
     ],
     "markdown.markdownItPlugins": true
   },
   "lint-staged": {
-    "*.ts": [
-      "eslint --fix"
-    ]
+    "*.ts": ["eslint --fix"]
   },
   "scripts": {
     "lint": "eslint src --ext ts",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 export const escapeForRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 export const footnoteRefRegex = /\[\^(?<key>\S+?)\](?!\:)/g;
-export const footnoteContentRegex = /^\[\^(?<key>\S+?)\](?=\: +)/gm;
+export const footnoteContentRegex = /^\[\^(?<key>\S+?)\](?=\:( +|$))/gm;
 
 export function buildFootnoteContentRegex(name: string) {
   return new RegExp(`^\\[\\^(?<key>${escapeForRegExp(name)})\\]\\: +(?<content>.*)$`, 'm');

--- a/test/workspace/test.md
+++ b/test/workspace/test.md
@@ -3,6 +3,10 @@
 test unicode: [^中文] [^🐈]
 test special characters: [^/\] [^$~*.]
 
+test multiline footnote with two spaces:[^multiline2]
+test multiline footnote with four spaces:[^multiline4]
+
+test multiline footnote with no spaces:[^multiline0]
 
 [^linestart]: line start
 
@@ -13,3 +17,15 @@ test special characters: [^/\] [^$~*.]
 [^/\]: special
 
 [^$~*.]: sdfsdf
+
+[^multiline2]:
+  line 1
+  line 2
+
+[^multiline4]:
+    line 1
+    line 2
+
+[^multiline0]:
+line 1
+line 2


### PR DESCRIPTION
Hello,

Please bear with me as this is the first pull request I have made.

The only thing of consequence that I changed in your code
is the regex on line 4 of `src/utils/index.ts`.

The other changes were just me attempting to create a new extension.
(I've never made a VS Code extension either.)

—eh

commit message follows

---

The existing footnote-body-matching regex
requires a space after the label's colon;
i.e., the line needs to start like '[^label]: '.

This does not provide for multiline footnote bodies,
where the first line can end with the ':'
and is followed by one or more indented lines.

The regex pattern introduced in this commit
does not require the existence of subsequent lines,
nor that any subsequent lines be indented.

Date:      Fri Nov 24 15:11:48 2023 -0500

On branch heckman
Changes to be committed:
	modified:   CHANGELOG.md
	modified:   README.md
	modified:   package-lock.json
	modified:   package.json
	modified:   src/utils/index.ts
	modified:   test/workspace/test.md